### PR TITLE
Fixes typo in product id

### DIFF
--- a/app.json
+++ b/app.json
@@ -547,7 +547,7 @@
       "zigbee": {
         "manufacturerName": "OSRAM",
         "productId": [
-          "Classic A60 W clear - LIGHTYFY"
+          "Classic A60 W clear - LIGHTIFY"
         ],
         "deviceId": [
           256


### PR DESCRIPTION
Adding Osram dimmable white fails. Maybe due to this typo?