### PR TITLE
Added new drivers for E27 RGBW Multicolor

### DIFF
--- a/app.json
+++ b/app.json
@@ -78,13 +78,23 @@
         "small": "drivers/lightify_rgbw/assets/images/small.png"
       },
       "zigbee": {
-        "manufacturerName": "OSRAM",
+        "manufacturerName": [
+          "OSRAM",
+          "LEDVANCE"
+        ],
         "productId": [
           "Classic A60 RGBW",
-          "CLA60 RGBW OSRAM"
+          "CLA60 RGBW OSRAM",
+          "CLA60 RGBW Z3"
         ],
-        "deviceId": 528,
-        "profileId": 49246,
+        "deviceId": [
+          528,
+          269
+        ],
+        "profileId": [
+          49246,
+          260
+        ],
         "learnmode": {
           "instruction": {
             "en": "Toggle the bulb to start pairing.\n\nIf pairing does not automatically start within 20 seconds, try resetting the device by toggling it 6 times (one toggle: 5 seconds off, 5 seconds on). It will flash to indicate it has been reset.",


### PR DESCRIPTION
Just got the new e27 classic light. App did not find it. 
They got new drivers.  So update the app 😄  And it works

Prod: Ledvance. 💡 
Product id CLA60 RGBW Z3
Device ID 269
Product ID 260
